### PR TITLE
updated setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,12 @@ from setuptools import setup, find_packages
 # Setup:
 setup(
     name='cosi_atmosphere',
-    version="dev",
+    version="0.0.1",
     url='https://github.com/cositools/cosi-atmosphere.git',
     author='COSI Team',
     author_email='christopher.m.karwin@nasa.gov',
     packages=find_packages(),
-    description = "Tools for calculating atmospheric response and background"
+    install_requires = ['histpy @ git+https://gitlab.com/burstcube/histpy.git@develop',
+                        'pandas','healpy','pymsis'],
+    description = 'Tools for calculating atmospheric response and background'
 )


### PR DESCRIPTION
Added install requirements to setup script. Also changed version from 'dev' to 0.0.1. Apparently, 'dev' is no longer allowed in newer python releases (>3.10). 